### PR TITLE
Rename references to 3857 to 4326, and introduce 3857 support

### DIFF
--- a/Runtime/Scripts/CoordinateSystem.cs
+++ b/Runtime/Scripts/CoordinateSystem.cs
@@ -24,12 +24,12 @@ namespace Netherlands3D.Coordinates
     public enum CoordinateSystem
     {
         Unity = -1, // Deprecated, Unity should not be considered a coordinate system but a translation by the MovingOrigin
-        EPSG_3857 = 3857, // WGS 84 / Pseudo-Mercator
+        EPSG_4326 = 4326, // WGS 84 / Pseudo-Mercator in degrees
         EPSG_4936 = 4936, // ETRS98-ECEF
         EPSG_7415 = 7415,
 
         // Commonly used aliases
-        WGS84 = EPSG_3857, // As an alias for WGS84, we assume the ArcGIS/Google Maps variety
+        WGS84 = EPSG_4326, // As an alias for WGS84, we assume the ArcGIS/Google Maps variety
         RD = EPSG_7415, // As an alias for RD, we assume RD Amersfoort New + NAP / RD3D
     }
 }


### PR DESCRIPTION
It surfaced that the current WGS84 conversions actually use EPSG:4326 and not EPSG:3857.

When this package was introduced, we incorrectly identified the WGS-84 handling as EPSG:3857 while it was EPSG:4326. This PR will fix that, and introduce support for EPSG:3857 as some providers, such as Tygron, use that