### PR TITLE
netherlands3d without space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eu.netherlands3d.coordinates",
-  "displayName": "Netherlands 3D - Coordinates Conversion",
+  "displayName": "Netherlands3D - Coordinates Conversion",
   "version": "1.1.0",
   "unity": "2022.2",
   "description": "",


### PR DESCRIPTION
Removed space in package name to match other packages.
This will make sure the search query 'Netherlands3D' will show all packages on OpenUPM.

<img width="257" alt="image" src="https://github.com/Netherlands3D/Coordinates/assets/11850024/a77f3528-a571-41e6-a883-e921f3a7cbe3">
