### PR TITLE
deprecated function return 3d when 2d is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] 05-05-2024
+
+### Fixed
+* many functions using the deprecated ConvertCoordinates.Convert-function convert to CoordinateSystem.RD, expecting a CoordinateSystem.RDNAP to be returned. 
+
+
+
 ## [1.4.2] 05-05-2024
 
 ### Fixed

--- a/Runtime/Scripts/Deprecated/CoordinateConverter.cs
+++ b/Runtime/Scripts/Deprecated/CoordinateConverter.cs
@@ -87,6 +87,13 @@ namespace Netherlands3D.Coordinates
         /// <exception cref="ArgumentOutOfRangeException">If conversion for the involved Coordinate Systems is not supported.</exception>
         public static Coordinate ConvertTo(Coordinate coordinate, CoordinateSystem targetCrs)
         {
+            CoordinateSystem _targetCoordinateSystem = targetCrs;
+            if (targetCrs == CoordinateSystem.RD)
+            {
+                _targetCoordinateSystem = CoordinateSystem.RDNAP;
+            }
+
+
             if (targetCrs == CoordinateSystem.Unity)
             {
                 Vector3 unityPos = coordinate.ToUnity();
@@ -96,10 +103,10 @@ namespace Netherlands3D.Coordinates
             if (coordinate.CoordinateSystem==-1)
             {
                 coordinate.ToVector3();
-                return new Coordinate(coordinate.ToVector3()).Convert(targetCrs);
+                return new Coordinate(coordinate.ToVector3()).Convert(_targetCoordinateSystem);
             }
-
-            return coordinate.Convert(targetCrs);
+            
+            return coordinate.Convert(_targetCoordinateSystem);
            //return ConvertTo(coordinate, (int)targetCrs);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.coordinates",
   "displayName": "Netherlands3D - Coordinates Conversion",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "unity": "2022.2",
   "description": "",
   "type": "library",


### PR DESCRIPTION
making sure that functions using the deprecated CoordinateConverter.ConvertTo requesting a rd-coordinate get the rdnap-coordinate they expect